### PR TITLE
Refactor IColorControllable

### DIFF
--- a/DisplayDriver10x11Clock.cpp
+++ b/DisplayDriver10x11Clock.cpp
@@ -14,12 +14,12 @@ int DisplayDriver10x11Clock::height() {
   return 10;
 }
 
-void DisplayDriver10x11Clock::setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) {
+void DisplayDriver10x11Clock::setDots(uint8_t count, uint32_t color) {
   uint8_t positions[4] = { 0, 1, 112, 113 };
   uint8_t i = 0;
 
   for (; i < count; i ++)
-    pixels.setPixelColor(positions[i], pixels.Color(red, green, blue));
+    pixels.setPixelColor(positions[i], color);
 
   for (; i < 4; i ++)
     pixels.setPixelColor(positions[i], 0);
@@ -29,9 +29,9 @@ uint32_t DisplayDriver10x11Clock::getPixel(uint8_t x, uint8_t y) {
   return pixels.getPixelColor(getPixelIndex(x, y));
 }
 
-void DisplayDriver10x11Clock::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
+void DisplayDriver10x11Clock::setPixel(uint8_t x, uint8_t y, uint32_t color) {
 
-  pixels.setPixelColor(getPixelIndex(x, y), pixels.Color(red, green, blue));
+  pixels.setPixelColor(getPixelIndex(x, y), color);
 }
 
 uint8_t DisplayDriver10x11Clock::getPixelIndex(uint8_t x, uint8_t y) {
@@ -47,15 +47,7 @@ uint8_t DisplayDriver10x11Clock::getPixelIndex(uint8_t x, uint8_t y) {
   return n;
 }
 
-void DisplayDriver10x11Clock::clearPixel(uint8_t x, uint8_t y) {
-  setPixel(x, y, 0, 0, 0);
-}
-
 void DisplayDriver10x11Clock::show() {
   pixels.show();
-}
-
-void DisplayDriver10x11Clock::clear() {
-  pixels.clear();
 }
 

--- a/DisplayDriver10x11Clock.h
+++ b/DisplayDriver10x11Clock.h
@@ -17,14 +17,11 @@ class DisplayDriver10x11Clock : public IDisplayDriver
     virtual int width();
     virtual int height();
     
-    virtual void setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue);
+    virtual void setDots(uint8_t count, uint32_t color);
 
     virtual uint32_t getPixel(uint8_t x, uint8_t y);
-    virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue);
-    virtual void clearPixel(uint8_t x, uint8_t y);
+    virtual void setPixel(uint8_t x, uint8_t y, uint32_t color);
 
-    void clear();
-    
     virtual void show();
 
   private:

--- a/DisplayDriverFablabNeaClock.cpp
+++ b/DisplayDriverFablabNeaClock.cpp
@@ -14,12 +14,12 @@ int DisplayDriverFablabNeaClock::height() {
   return 10;
 }
 
-void DisplayDriverFablabNeaClock::setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) {
+void DisplayDriverFablabNeaClock::setDots(uint8_t count, uint32_t color) {
   uint8_t positions[4] = { 111, 112, 113, 110 };
   uint8_t i = 0;
 
   for (; i < count; i ++)
-    pixels.setPixelColor(positions[i], pixels.Color(red, green, blue));
+    pixels.setPixelColor(positions[i], color);
 
   for (; i < 4; i ++)
     pixels.setPixelColor(positions[i], 0);
@@ -29,9 +29,8 @@ uint32_t DisplayDriverFablabNeaClock::getPixel(uint8_t x, uint8_t y) {
   return pixels.getPixelColor(getPixelIndex(x, y));
 }
 
-void DisplayDriverFablabNeaClock::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
-
-  pixels.setPixelColor(getPixelIndex(x, y), pixels.Color(red, green, blue));
+void DisplayDriverFablabNeaClock::setPixel(uint8_t x, uint8_t y, uint32_t color) {
+  pixels.setPixelColor(getPixelIndex(x, y), color);
 }
 
 uint8_t DisplayDriverFablabNeaClock::getPixelIndex(uint8_t x, uint8_t y) {
@@ -42,15 +41,7 @@ uint8_t DisplayDriverFablabNeaClock::getPixelIndex(uint8_t x, uint8_t y) {
   return y * width() + x;
 }
 
-void DisplayDriverFablabNeaClock::clearPixel(uint8_t x, uint8_t y) {
-  setPixel(x, y, 0, 0, 0);
-}
-
 void DisplayDriverFablabNeaClock::show() {
   pixels.show();
-}
-
-void DisplayDriverFablabNeaClock::clear() {
-  pixels.clear();
 }
 

--- a/DisplayDriverFablabNeaClock.h
+++ b/DisplayDriverFablabNeaClock.h
@@ -17,14 +17,11 @@ class DisplayDriverFablabNeaClock : public IDisplayDriver
     virtual int width();
     virtual int height();
     
-    virtual void setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue);
+    virtual void setDots(uint8_t count, uint32_t color);
 
     virtual uint32_t getPixel(uint8_t x, uint8_t y);
-    virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue);
-    virtual void clearPixel(uint8_t x, uint8_t y);
+    virtual void setPixel(uint8_t x, uint8_t y, uint32_t color);
 
-    void clear();
-    
     virtual void show();
 
   private:

--- a/DisplayDriverFrickelClock.cpp
+++ b/DisplayDriverFrickelClock.cpp
@@ -18,13 +18,13 @@ uint32_t DisplayDriverFrickelClock::getPixel(uint8_t x, uint8_t y) {
   return pixels.getPixelColor(getPixelIndex(x, y));
 }
 
-void DisplayDriverFrickelClock::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
+void DisplayDriverFrickelClock::setPixel(uint8_t x, uint8_t y, uint32_t color) {
   if (y == 9) {
     if (x >= 4 && x <= 7)
       return;
   }
 
-  pixels.setPixelColor(getPixelIndex(x, y), pixels.Color(red, green, blue));
+  pixels.setPixelColor(getPixelIndex(x, y), color);
 }
 
 uint8_t DisplayDriverFrickelClock::getPixelIndex(uint8_t x, uint8_t y) {
@@ -40,17 +40,7 @@ uint8_t DisplayDriverFrickelClock::getPixelIndex(uint8_t x, uint8_t y) {
   return n;
 }
 
-void DisplayDriverFrickelClock::clearPixel(uint8_t x, uint8_t y) {
-  setPixel(x, y, 0, 0, 0);
-}
-
 void DisplayDriverFrickelClock::show() {
   pixels.show();
 }
-
-void DisplayDriverFrickelClock::clear() {
-  pixels.clear();
-}
-
-
 

--- a/DisplayDriverFrickelClock.h
+++ b/DisplayDriverFrickelClock.h
@@ -17,14 +17,11 @@ class DisplayDriverFrickelClock : public IDisplayDriver
     virtual int width();
     virtual int height();
 
-    virtual void setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) { }
+    virtual void setDots(uint8_t count, uint32_t color) { }
     
     virtual uint32_t getPixel(uint8_t x, uint8_t y);
-    virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue);
-    virtual void clearPixel(uint8_t x, uint8_t y);
+    virtual void setPixel(uint8_t x, uint8_t y, uint32_t color);
 
-    void clear();
-    
     virtual void show();
 
   private:

--- a/FallingStarAnimator.cpp
+++ b/FallingStarAnimator.cpp
@@ -49,14 +49,6 @@ bool FallingStar::animate() {
   return false;
 }
 
-void FallingStarAnimator::setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setDots(count, pack(red, green, blue));
-}
-
-void FallingStarAnimator::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setPixel(x, y, pack(red, green, blue));
-}
-
 void FallingStarAnimator::clearPixel(uint8_t x, uint8_t y) {
   if (starCount == FALLING_STAR_LIMIT) {
     Serial.print("FALLING_STAR_LIMIT reached\n");

--- a/FallingStarAnimator.cpp
+++ b/FallingStarAnimator.cpp
@@ -19,7 +19,7 @@ bool FallingStar::animate() {
   }
 
   if (applied)
-    driver->clearPixel(x, y);
+    driver->setPixel(x, y, 0);
 
   y ++;
 
@@ -44,24 +44,23 @@ bool FallingStar::animate() {
   b *= FALLING_STAR_FACTOR;
 
   color = ((uint32_t)r << 16) | ((uint32_t)g <<  8) | ((uint32_t)b <<  0);
-
-  driver->setPixel(x, y, r, g, b);
+  driver->setPixel(x, y, color);
   applied = true;
   return false;
 }
 
 void FallingStarAnimator::setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setDots(count, red, green, blue);
+  driver->setDots(count, pack(red, green, blue));
 }
 
 void FallingStarAnimator::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setPixel(x, y, red, green, blue);
+  driver->setPixel(x, y, pack(red, green, blue));
 }
 
 void FallingStarAnimator::clearPixel(uint8_t x, uint8_t y) {
   if (starCount == FALLING_STAR_LIMIT) {
     Serial.print("FALLING_STAR_LIMIT reached\n");
-    driver->clearPixel(x, y);
+    driver->setPixel(x, y, 0);
     return;
   }
   

--- a/FallingStarAnimator.h
+++ b/FallingStarAnimator.h
@@ -2,8 +2,7 @@
 #define FALLING_STAR_ANIMATOR_H
 
 #include <Arduino.h>
-#include "IDisplayDriver.h"
-#include "IAnimator.h"
+#include "NullAnimator.h"
 
 #define FALLING_STAR_LIMIT 20
 
@@ -25,18 +24,15 @@ class FallingStar
     bool animate();
 };
 
-class FallingStarAnimator: public IAnimator
+class FallingStarAnimator: public NullAnimator
 {
   private:
-    IDisplayDriver *driver;
     FallingStar stars[FALLING_STAR_LIMIT];
     uint8_t starCount = 0;
 
   public:
-    FallingStarAnimator(IDisplayDriver *driver): driver(driver) { }
+    FallingStarAnimator(IDisplayDriver *driver): NullAnimator(driver) { }
 
-    virtual void setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue);
-    virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue);
     virtual void clearPixel(uint8_t x, uint8_t y);
     virtual void commit();
 };

--- a/IAnimator.h
+++ b/IAnimator.h
@@ -2,12 +2,13 @@
 #define I_ANIMATOR_H
 
 #include <stdint.h>
+#include "IColorControllable.h"
 
-class IAnimator
+class IAnimator : public IColorControllable
 {
   public:
-    virtual void setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) = 0;
-    virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) = 0;
+    virtual void setDots(uint8_t count) = 0;
+    virtual void setPixel(uint8_t x, uint8_t y) = 0;
     virtual void clearPixel(uint8_t x, uint8_t y) = 0;
     virtual void commit() = 0;
 

--- a/IAnimator.h
+++ b/IAnimator.h
@@ -10,6 +10,11 @@ class IAnimator
     virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) = 0;
     virtual void clearPixel(uint8_t x, uint8_t y) = 0;
     virtual void commit() = 0;
+
+  protected:
+    uint32_t pack(uint8_t r, uint8_t g, uint8_t b) { 
+      return ((uint32_t)r << 16) | ((uint32_t)g <<  8) | ((uint32_t)b <<  0);
+    }
 };
 
 

--- a/IDisplayDriver.h
+++ b/IDisplayDriver.h
@@ -8,11 +8,10 @@ class IDisplayDriver
   public:
     virtual int width() = 0;
     virtual int height() = 0;
-    virtual void setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) = 0;
+    virtual void setDots(uint8_t count, uint32_t color) = 0;
 
     virtual uint32_t getPixel(uint8_t x, uint8_t y) = 0;
-    virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) = 0;
-    virtual void clearPixel(uint8_t x, uint8_t y) = 0;
+    virtual void setPixel(uint8_t x, uint8_t y, uint32_t color) = 0;
 
     virtual void show() = 0;
 };

--- a/IncrementalAnimator.cpp
+++ b/IncrementalAnimator.cpp
@@ -1,17 +1,17 @@
 #include "IncrementalAnimator.h"
 
 void IncrementalAnimator::setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setDots(count, red, green, blue);
+  driver->setDots(count, pack(red, green, blue));
 }
 
 void IncrementalAnimator::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setPixel(x, y, red, green, blue);
+  driver->setPixel(x, y, pack(red, green, blue));
   driver->show();
   delay(100);
 }
 
 void IncrementalAnimator::clearPixel(uint8_t x, uint8_t y) {
-  driver->clearPixel(x, y);
+  driver->setPixel(x, y, 0);
   driver->show();
   delay(100);
 }

--- a/IncrementalAnimator.cpp
+++ b/IncrementalAnimator.cpp
@@ -1,10 +1,6 @@
 #include "IncrementalAnimator.h"
 
-void IncrementalAnimator::setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setDots(count, pack(red, green, blue));
-}
-
-void IncrementalAnimator::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
+void IncrementalAnimator::setPixel(uint8_t x, uint8_t y) {
   driver->setPixel(x, y, pack(red, green, blue));
   driver->show();
   delay(100);
@@ -14,8 +10,4 @@ void IncrementalAnimator::clearPixel(uint8_t x, uint8_t y) {
   driver->setPixel(x, y, 0);
   driver->show();
   delay(100);
-}
-
-void IncrementalAnimator::commit() {
-  driver->show();
 }

--- a/IncrementalAnimator.h
+++ b/IncrementalAnimator.h
@@ -3,20 +3,15 @@
 
 #include <Arduino.h>
 #include "IDisplayDriver.h"
-#include "IAnimator.h"
+#include "NullAnimator.h"
 
-class IncrementalAnimator: public IAnimator
+class IncrementalAnimator: public NullAnimator
 {
-  private:
-    IDisplayDriver *driver;
-
   public:
-    IncrementalAnimator(IDisplayDriver *driver): driver(driver) { }
+    IncrementalAnimator(IDisplayDriver *driver): NullAnimator(driver) { }
 
-    virtual void setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue);
-    virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue);
+    virtual void setPixel(uint8_t x, uint8_t y);
     virtual void clearPixel(uint8_t x, uint8_t y);
-    virtual void commit();
 };
 
 

--- a/NullAnimator.cpp
+++ b/NullAnimator.cpp
@@ -17,21 +17,38 @@ void NullAnimator::commit() {
 }
 
 void NullAnimator::setRed(uint8_t red) {
+  if (red == 0 && green == 0 && blue == 0) {
+    red = 1; // don't actually turn off the last LED
+  }
+
   updateColors(pack(this->red, green, blue), pack(red, green, blue));
   this->red = red;
 }
 
 void NullAnimator::setGreen(uint8_t green) {
+  if (red == 0 && green == 0 && blue == 0) {
+    green = 1; // don't actually turn off the last LED
+  }
+
   updateColors(pack(red, this->green, blue), pack(red, green, blue));
   this->green = green;
 }
 
 void NullAnimator::setBlue(uint8_t blue) {
+  if (red == 0 && green == 0 && blue == 0) {
+    blue = 1; // don't actually turn off the last LED
+  }
+
   updateColors(pack(red, green, this->blue), pack(red, green, blue));
   this->blue = blue;
 }
 
 void NullAnimator::updateColors(uint32_t oldColor, uint32_t newColor) {
+  if (oldColor == 0) {
+    // don't update if old color was black, otherwise all LEDs would be enabled
+    return;
+  }
+
   for (uint8_t y = 0; y < driver->height(); y ++) {
     for (uint8_t x = 0; x < driver->width(); x ++) {
       if (driver->getPixel(x, y) == oldColor) {
@@ -39,4 +56,6 @@ void NullAnimator::updateColors(uint32_t oldColor, uint32_t newColor) {
       }
     }
   }
+
+  commit();
 }

--- a/NullAnimator.cpp
+++ b/NullAnimator.cpp
@@ -1,15 +1,15 @@
 #include "NullAnimator.h"
 
 void NullAnimator::setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setDots(count, red, green, blue);
+  driver->setDots(count, pack(red, green, blue));
 }
 
 void NullAnimator::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
-  driver->setPixel(x, y, red, green, blue);
+  driver->setPixel(x, y, pack(red, green, blue));
 }
 
 void NullAnimator::clearPixel(uint8_t x, uint8_t y) {
-  driver->clearPixel(x, y);
+  driver->setPixel(x, y, 0);
 }
 
 void NullAnimator::commit() {

--- a/NullAnimator.cpp
+++ b/NullAnimator.cpp
@@ -1,10 +1,10 @@
 #include "NullAnimator.h"
 
-void NullAnimator::setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue) {
+void NullAnimator::setDots(uint8_t count) {
   driver->setDots(count, pack(red, green, blue));
 }
 
-void NullAnimator::setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue) {
+void NullAnimator::setPixel(uint8_t x, uint8_t y) {
   driver->setPixel(x, y, pack(red, green, blue));
 }
 
@@ -14,4 +14,29 @@ void NullAnimator::clearPixel(uint8_t x, uint8_t y) {
 
 void NullAnimator::commit() {
   driver->show();
+}
+
+void NullAnimator::setRed(uint8_t red) {
+  updateColors(pack(this->red, green, blue), pack(red, green, blue));
+  this->red = red;
+}
+
+void NullAnimator::setGreen(uint8_t green) {
+  updateColors(pack(red, this->green, blue), pack(red, green, blue));
+  this->green = green;
+}
+
+void NullAnimator::setBlue(uint8_t blue) {
+  updateColors(pack(red, green, this->blue), pack(red, green, blue));
+  this->blue = blue;
+}
+
+void NullAnimator::updateColors(uint32_t oldColor, uint32_t newColor) {
+  for (uint8_t y = 0; y < driver->height(); y ++) {
+    for (uint8_t x = 0; x < driver->width(); x ++) {
+      if (driver->getPixel(x, y) == oldColor) {
+        driver->setPixel(x, y, newColor);
+      }
+    }
+  }
 }

--- a/NullAnimator.h
+++ b/NullAnimator.h
@@ -7,16 +7,27 @@
 
 class NullAnimator: public IAnimator
 {
-  private:
+  protected:
     IDisplayDriver *driver;
+
+    uint8_t red = 255;
+    uint8_t green = 255;
+    uint8_t blue = 255;
 
   public:
     NullAnimator(IDisplayDriver *driver): driver(driver) { }
 
-    virtual void setDots(uint8_t count, uint8_t red, uint8_t green, uint8_t blue);
-    virtual void setPixel(uint8_t x, uint8_t y, uint8_t red, uint8_t green, uint8_t blue);
+    virtual void setRed(uint8_t red);
+    virtual void setGreen(uint8_t green);
+    virtual void setBlue(uint8_t blue);
+
+    virtual void setDots(uint8_t count);
+    virtual void setPixel(uint8_t x, uint8_t y);
     virtual void clearPixel(uint8_t x, uint8_t y);
     virtual void commit();
+
+  private:
+    void updateColors(uint32_t oldColor, uint32_t newColor);
 };
 
 

--- a/PersistentColors.cpp
+++ b/PersistentColors.cpp
@@ -7,16 +7,22 @@ void PersistentColors::setup() {
 }
 
 void PersistentColors::setRed(uint8_t red) {
+  colorControllable->setRed(red);
+
   persistentStorage.red = red;
   persistentStorage.commit();
 }
 
 void PersistentColors::setGreen(uint8_t green) {
+  colorControllable->setGreen(green);
+
   persistentStorage.green = green;
   persistentStorage.commit();
 }
 
 void PersistentColors::setBlue(uint8_t blue) {
+  colorControllable->setBlue(blue);
+
   persistentStorage.blue = blue;
   persistentStorage.commit();
 }

--- a/Word.cpp
+++ b/Word.cpp
@@ -1,8 +1,8 @@
 #include "Word.h"
 
-void Word::show(IAnimator *animator, uint8_t r, uint8_t g, uint8_t b) const {
+void Word::show(IAnimator *animator) const {
   for (uint8_t i = 0; i < length; i ++)
-    animator->setPixel(x + i, y, r, g, b);
+    animator->setPixel(x + i, y);
 }
 
 void Word::hide(IAnimator *animator) const {

--- a/Word.h
+++ b/Word.h
@@ -17,7 +17,7 @@ class Word {
       assert(length <= 11);
     }
 
-    void show(IAnimator *animator, uint8_t r, uint8_t g, uint8_t b) const;
+    void show(IAnimator *animator) const;
     void hide(IAnimator *animator) const;
 
     bool operator == (const Word& w) const {

--- a/WordClockScene.cpp
+++ b/WordClockScene.cpp
@@ -15,18 +15,13 @@ uint8_t WordClockScene::getDotsCount(time_t time) {
 }
 
 void WordClockScene::showWords(WordList &nextWords, time_t time) {
-  nextWords.diff(currentWords).show(animator, red, green, blue);
+  nextWords.diff(currentWords).show(animator);
   currentWords.diff(nextWords).hide(animator);
 
-  animator->setDots(getDotsCount(time), red, green, blue);
+  animator->setDots(getDotsCount(time));
   animator->commit();
   
   currentWords = nextWords;
-}
-
-void WordClockScene::clearScreen() {
-  WordList noWords;
-  showWords(noWords, getLocalTime());
 }
 
 time_t WordClockScene::getLocalTime() {

--- a/WordClockScene.h
+++ b/WordClockScene.h
@@ -4,32 +4,21 @@
 #include <Time.h>
 #include <Timezone.h>  // https://github.com/JChristensen/Timezone
 #include "IAnimator.h"
-#include "IColorControllable.h"
 #include "IWordingStrategy.h"
 #include "WordList.h"
 
-class WordClockScene : public IColorControllable {
+class WordClockScene {
   private:
     IAnimator *animator;
-
-    uint8_t red = 255;
-    uint8_t green = 255;
-    uint8_t blue = 255;
-
     WordList currentWords;
 
   protected:
     IWordingStrategy *wordingStrategy;
-
     
   public:
     WordClockScene(IAnimator *animator, IWordingStrategy *wordingStrategy)
       : animator(animator), wordingStrategy(wordingStrategy) { }
     void loop();
-
-    virtual void setRed(uint8_t red) { this->red = red; clearScreen(); }
-    virtual void setGreen(uint8_t green) { this->green = green; clearScreen(); }
-    virtual void setBlue(uint8_t blue) { this->blue = blue; clearScreen(); }
 
   protected:
     virtual WordList getWords(time_t time);
@@ -38,7 +27,6 @@ class WordClockScene : public IColorControllable {
 
   private:
     void showWords(WordList &nextWords, time_t time);
-    void clearScreen();
 };
 
 #endif /* !WORD_CLOCK_SCENE_H */

--- a/WordList.cpp
+++ b/WordList.cpp
@@ -5,9 +5,9 @@ void WordList::add(const Word w) {
   words[length ++] = w;
 }
 
-void WordList::show(IAnimator *animator, uint8_t r, uint8_t g, uint8_t b) const {
+void WordList::show(IAnimator *animator) const {
   for (uint8_t i = 0; i < length; i ++)
-    words[i].show(animator, r, g, b);
+    words[i].show(animator);
 }
 
 void WordList::hide(IAnimator *animator) const {

--- a/WordList.h
+++ b/WordList.h
@@ -10,7 +10,7 @@ class WordList {
 
   public:
     void add(const Word w);
-    void show(IAnimator *animator, uint8_t r, uint8_t g, uint8_t b) const;
+    void show(IAnimator *animator) const;
     void hide(IAnimator *animator) const;
 
     WordList diff(WordList &diffWords) const;

--- a/wordClock.ino
+++ b/wordClock.ino
@@ -55,7 +55,13 @@ MockWordClockScene wordClockScene = { &animator, &strategy };
 #endif
 
 PersistentColors persistentColors = { &animator };
-MqttController *mqttController = new MqttController(&persistentColors, wifiClient);
+
+// MQTT Controller can be "configured" to either update persistent colors, i.e. store each
+// changed value to EEPROM immediately.  Use this if you want the clock to reset with colors
+// updated via EEPROM.
+//MqttController *mqttController = new MqttController(&persistentColors, wifiClient);
+// Influence animator directly (use this if you intend to update colors often)
+MqttController *mqttController = new MqttController(&animator, wifiClient);
 
 static void setupWifiAP() {
   IPAddress apIP(192, 168, 4, 1);

--- a/wordClock.ino
+++ b/wordClock.ino
@@ -54,7 +54,7 @@ WordClockScene wordClockScene = { &animator, &strategy };
 MockWordClockScene wordClockScene = { &animator, &strategy };
 #endif
 
-PersistentColors persistentColors = { &wordClockScene };
+PersistentColors persistentColors = { &animator };
 MqttController *mqttController = new MqttController(&persistentColors, wifiClient);
 
 static void setupWifiAP() {


### PR DESCRIPTION
Refactor code so that ...

* `IDisplayDriver` uses `uint32_t` to encode color at all places (i.e. no difference between `getPixel` and `setPixel` API)
* no longer implement `IColorControllable` on WordClockScene
* ... instead on all the animators
* ... so these can implement individual rules on how to implement color changes

Updated MqttController to show how to repeatedly (and now directly without applying falling-star animations) update colors, even w/o writing to EEPROM each and every time.

/cc @jalr 